### PR TITLE
Added "one_shot: true;" to all rules to make them match max. once.

### DIFF
--- a/local.d/_multimap_adult.conf
+++ b/local.d/_multimap_adult.conf
@@ -12,6 +12,7 @@ adult_subject_de {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_adult_subject_de.map";
   score = 10.0;
   symbol = "ADULT_SUBJECT_DE";
@@ -22,6 +23,7 @@ adult_subject_en {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_adult_subject_en.map";
   score = 10.0;
   symbol = "ADULT_SUBJECT_EN";
@@ -34,6 +36,7 @@ adult_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_adult_de.map";
   score = 10.0;
   symbol = "ADULT_DE";
@@ -44,6 +47,7 @@ adult_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_adult_en.map";
   score = 10.0;
   symbol = "ADULT_EN";

--- a/local.d/_multimap_base_phrases.conf
+++ b/local.d/_multimap_base_phrases.conf
@@ -12,6 +12,7 @@ base_phrases_badlang_subject_de {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_base_phrases_subject_badlang_de.map";
   score = 10.0;
   symbol = "BASE_PHRASES_SUBJECT_BADLANG_DE";
@@ -22,6 +23,7 @@ base_phrases_badlang_subject_en {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_base_phrases_subject_badlang_en.map";
   score = 10.0;
   symbol = "BASE_PHRASES_SUBJECT_BADLANG_EN";
@@ -32,6 +34,7 @@ base_phrases_subject_de {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_base_phrases_subject_de.map";
   score = 10.0;
   symbol = "BASE_PHRASES_SUBJECT_DE";
@@ -42,6 +45,7 @@ base_phrases_subject_en {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_base_phrases_subject_en.map";
   score = 10.0;
   symbol = "BASE_PHRASES_SUBJECT_EN";
@@ -55,6 +59,7 @@ base_phrases_badlang_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_base_phrases_badlang_de.map";
   score = 10.0;
   symbol = "BASE_PHRASES_BADLANG_DE";
@@ -65,6 +70,7 @@ base_phrases_badlang_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_base_phrases_badlang_en.map";
   score = 10.0;
   symbol = "BASE_PHRASES_BADLANG_EN";
@@ -75,6 +81,7 @@ base_phrases_greeting_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_base_phrases_greeting_de.map";
   score = 10.0;
   symbol = "BASE_PHRASES_GREETING_DE";
@@ -85,6 +92,7 @@ base_phrases_greeting_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_base_phrases_greeting_en.map";
   score = 10.0;
   symbol = "BASE_PHRASES_GREETING_EN";
@@ -95,6 +103,7 @@ base_phrases_unsub_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_base_phrases_unsub_de.map";
   score = 10.0;
   symbol = "BASE_PHRASES_UNSUB_DE";
@@ -105,6 +114,7 @@ base_phrases_unsub_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_base_phrases_unsub_en.map";
   score = 10.0;
   symbol = "BASE_PHRASES_UNSUB_EN";
@@ -117,6 +127,7 @@ base_phrases_h_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_base_phrases_h_de.map";
   score = 10.0;
   symbol = "BASE_PHRASES_H_DE";
@@ -127,6 +138,7 @@ base_phrases_h_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_base_phrases_h_en.map";
   score = 10.0;
   symbol = "BASE_PHRASES_H_EN";
@@ -138,6 +150,7 @@ base_phrases_m_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_base_phrases_m_de.map";
   score = 5.0;
   symbol = "BASE_PHRASES_M_DE";
@@ -148,6 +161,7 @@ base_phrases_m_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_base_phrases_m_en.map";
   score = 5.0;
   symbol = "BASE_PHRASES_M_EN";

--- a/local.d/_multimap_casino.conf
+++ b/local.d/_multimap_casino.conf
@@ -12,6 +12,7 @@ casino_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_casino_de.map";
   score = 10.0;
   symbol = "CASINO_DE";
@@ -22,6 +23,7 @@ casino_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_casino_en.map";
   score = 10.0;
   symbol = "CASINO_EN";

--- a/local.d/_multimap_domain.conf
+++ b/local.d/_multimap_domain.conf
@@ -20,6 +20,7 @@ domain_twitter {
   type = "content";
   filter = "rawtext";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_domain_twitter.map";
   score = 10.0;
   symbol = "DOMAIN_TWITTER";

--- a/local.d/_multimap_domain_trigger.conf
+++ b/local.d/_multimap_domain_trigger.conf
@@ -9,6 +9,7 @@ domain_trigger {
   type = "url";
   filter = "full";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_domain_trigger.map";
   score = 0.5;
   symbol = "DOMAIN_TRIGGER";

--- a/local.d/_multimap_finance.conf
+++ b/local.d/_multimap_finance.conf
@@ -14,6 +14,7 @@ finance_subject_de {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_finance_subject_de.map";
   score = 10.0;
   symbol = "FINANCE_SUBJECT_DE";
@@ -24,6 +25,7 @@ finance_subject_en {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_finance_subject_en.map";
   score = 10.0;
   symbol = "FINANCE_SUBJECT_EN";
@@ -36,6 +38,7 @@ finance_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_finance_de.map";
   score = 10.0;
   symbol = "FINANCE_DE";
@@ -46,6 +49,7 @@ finance_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_finance_en.map";
   score = 10.0;
   symbol = "FINANCE_EN";

--- a/local.d/_multimap_health.conf
+++ b/local.d/_multimap_health.conf
@@ -12,6 +12,7 @@ health_subject_en {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_health_subject_en.map";
   score = 10.0;
   symbol = "HEALTH_SUBJECT_EN";
@@ -22,6 +23,7 @@ health_med_name {
   type = "content";
   filter = "text";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_health_med_name.map";
   score = 0.5;
   symbol = "HEALTH_MED_NAMES";
@@ -34,6 +36,7 @@ health_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_health_de.map";
   score = 10.0;
   symbol = "HEALTH_DE";
@@ -44,6 +47,7 @@ health_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_health_en.map";
   score = 10.0;
   symbol = "HEALTH_EN";
@@ -54,6 +58,7 @@ health_men_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_health_men_de.map";
   score = 10.0;
   symbol = "HEALTH_MEN_DE";
@@ -64,6 +69,7 @@ health_men_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_health_men_en.map";
   score = 10.0;
   symbol = "HEALTH_MEN_EN";
@@ -74,6 +80,7 @@ health_wl_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_health_wl_de.map";
   score = 10.0;
   symbol = "HEALTH_WL_DE";
@@ -84,6 +91,7 @@ health_wl_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_health_wl_en.map";
   score = 10.0;
   symbol = "HEALTH_WL_EN";

--- a/local.d/_multimap_makemoney.conf
+++ b/local.d/_multimap_makemoney.conf
@@ -12,6 +12,7 @@ makemoney_subject_de {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_makemoney_subject_de.map";
   score = 10.0;
   symbol = "MAKEMONEY_SUBJECT_DE";
@@ -22,6 +23,7 @@ makemoney_subject_en {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_makemoney_subject_en.map";
   score = 10.0;
   symbol = "MAKEMONEY_SUBJECT_EN";
@@ -34,6 +36,7 @@ makemoney_btc_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_makemoney_btc_de.map";
   score = 10.0;
   symbol = "MAKEMONEY_BTC_DE";
@@ -44,6 +47,7 @@ makemoney_btc_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_makemoney_btc_en.map";
   score = 10.0;
   symbol = "MAKEMONEY_BTC_EN";
@@ -54,6 +58,7 @@ makemoney_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_makemoney_de.map";
   score = 10.0;
   symbol = "MAKEMONEY_DE";
@@ -64,6 +69,7 @@ makemoney_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_makemoney_en.map";
   score = 10.0;
   symbol = "MAKEMONEY_EN";

--- a/local.d/_multimap_phishing.conf
+++ b/local.d/_multimap_phishing.conf
@@ -13,6 +13,7 @@ phishing_sender_de {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_sender_de.map";
   score = 10.0;
   symbol = "PHISHING_SENDER_DE";
@@ -24,6 +25,7 @@ phishing_sender_en {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_sender_en.map";
   score = 10.0;
   symbol = "PHISHING_SENDER_EN";
@@ -36,6 +38,7 @@ phishing_subject_de {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_subject_de.map";
   score = 10.0;
   symbol = "PHISHING_SUBJECT_DE";
@@ -46,6 +49,7 @@ phishing_subject_en {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_subject_en.map";
   score = 10.0;
   symbol = "PHISHING_SUBJECT_EN";
@@ -58,6 +62,7 @@ phishing_account_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_account_de.map";
   score = 10.0;
   symbol = "PHISHING_ACCOUNT_DE";
@@ -68,6 +73,7 @@ phishing_account_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_account_en.map";
   score = 10.0;
   symbol = "PHISHING_ACCOUNT_EN";
@@ -78,6 +84,7 @@ phishing_banking_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_banking_de.map";
   score = 10.0;
   symbol = "PHISHING_BANKING_DE";
@@ -88,6 +95,7 @@ phishing_banking_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_banking_en.map";
   score = 10.0;
   symbol = "PHISHING_BANKING_EN";
@@ -98,6 +106,7 @@ phishing_email_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_email_de.map";
   score = 10.0;
   symbol = "PHISHING_EMAIL_DE";
@@ -108,6 +117,7 @@ phishing_email_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_email_en.map";
   score = 10.0;
   symbol = "PHISHING_EMAIL_EN";
@@ -118,6 +128,7 @@ phishing_hosting_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_hosting_de.map";
   score = 10.0;
   symbol = "PHISHING_HOSTING_DE";
@@ -128,6 +139,7 @@ phishing_hosting_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_hosting_en.map";
   score = 10.0;
   symbol = "PHISHING_HOSTING_EN";
@@ -138,6 +150,7 @@ phishing_parcel_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_parcel_de.map";
   score = 10.0;
   symbol = "PHISHING_PARCEL_DE";
@@ -148,6 +161,7 @@ phishing_parcel_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_parcel_en.map";
   score = 10.0;
   symbol = "PHISHING_PARCEL_EN";
@@ -158,6 +172,7 @@ phishing_rewards_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_rewards_de.map";
   score = 10.0;
   symbol = "PHISHING_REWARDS_DE";
@@ -168,6 +183,7 @@ phishing_rewards_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_rewards_en.map";
   score = 10.0;
   symbol = "PHISHING_REWARDS_EN";
@@ -178,6 +194,7 @@ phishing_survey_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_survey_de.map";
   score = 10.0;
   symbol = "PHISHING_SURVEY_DE";
@@ -188,6 +205,7 @@ phishing_survey_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_survey_en.map";
   score = 10.0;
   symbol = "PHISHING_SURVEY_EN";
@@ -200,6 +218,7 @@ phishing_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_de.map";
   score = 10.0;
   symbol = "PHISHING_DE";
@@ -210,6 +229,7 @@ phishing_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_phishing_en.map";
   score = 10.0;
   symbol = "PHISHING_EN";

--- a/local.d/_multimap_sale.conf
+++ b/local.d/_multimap_sale.conf
@@ -13,6 +13,7 @@ sale_sender_de {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_sale_sender_de.map";
   score = 10.0;
   symbol = "SALE_SENDER_DE";
@@ -24,6 +25,7 @@ sale_sender_en {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_sale_sender_en.map";
   score = 10.0;
   symbol = "SALE_SENDER_EN";
@@ -36,6 +38,7 @@ sale_subject_de {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_sale_subject_de.map";
   score = 10.0;
   symbol = "SALE_SUBJECT_DE";
@@ -46,6 +49,7 @@ sale_subject_en {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_sale_subject_en.map";
   score = 10.0;
   symbol = "SALE_SUBJECT_EN";
@@ -58,6 +62,7 @@ sale_seo_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_sale_seo_de.map";
   score = 10.0;
   symbol = "SALE_SEO_DE";
@@ -68,6 +73,7 @@ sale_seo_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_sale_seo_en.map";
   score = 10.0;
   symbol = "SALE_SEO_EN";
@@ -78,6 +84,7 @@ sale_website_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_sale_website_de.map";
   score = 10.0;
   symbol = "SALE_WEBSITE_DE";
@@ -88,6 +95,7 @@ sale_website_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_sale_website_en.map";
   score = 10.0;
   symbol = "SALE_WEBSITE_EN";
@@ -98,6 +106,7 @@ sale_internet_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_sale_internet_de.map";
   score = 10.0;
   symbol = "SALE_INTERNET_DE";
@@ -108,6 +117,7 @@ sale_internet_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_sale_internet_en.map";
   score = 10.0;
   symbol = "SALE_INTERNET_EN";
@@ -119,6 +129,7 @@ sale_h_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_sale_h_de.map";
   score = 10.0;
   symbol = "SALE_H_DE";
@@ -129,6 +140,7 @@ sale_h_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_sale_h_en.map";
   score = 10.0;
   symbol = "SALE_H_EN";

--- a/local.d/_multimap_scam.conf
+++ b/local.d/_multimap_scam.conf
@@ -12,6 +12,7 @@ scam_subject_de {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_subject_de.map";
   score = 10.0;
   symbol = "SCAM_SUBJECT_DE";
@@ -22,6 +23,7 @@ scam_subject_en {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_subject_en.map";
   score = 10.0;
   symbol = "SCAM_SUBJECT_EN";
@@ -34,6 +36,7 @@ scam_atmcard_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_atmcard_de.map";
   score = 10.0;
   symbol = "SCAM_ATMCARD_DE";
@@ -44,6 +47,7 @@ scam_atmcard_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_atmcard_en.map";
   score = 10.0;
   symbol = "SCAM_ATMCARD_EN";
@@ -54,6 +58,7 @@ scam_business_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_business_de.map";
   score = 10.0;
   symbol = "SCAM_BUSINESS_DE";
@@ -64,6 +69,7 @@ scam_business_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_business_en.map";
   score = 10.0;
   symbol = "SCAM_BUSINESS_EN";
@@ -74,6 +80,7 @@ scam_donation_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_donation_de.map";
   score = 10.0;
   symbol = "SCAM_DONATION_DE";
@@ -84,6 +91,7 @@ scam_donation_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_donation_en.map";
   score = 10.0;
   symbol = "SCAM_DONATION_EN";
@@ -94,6 +102,7 @@ scam_funds_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_funds_de.map";
   score = 10.0;
   symbol = "SCAM_FUNDS_DE";
@@ -104,6 +113,7 @@ scam_funds_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_funds_en.map";
   score = 10.0;
   symbol = "SCAM_FUNDS_EN";
@@ -114,6 +124,7 @@ scam_invest_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_invest_de.map";
   score = 10.0;
   symbol = "SCAM_INVEST_DE";
@@ -124,6 +135,7 @@ scam_invest_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_invest_en.map";
   score = 10.0;
   symbol = "SCAM_INVEST_EN";
@@ -134,6 +146,7 @@ scam_order_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_order_de.map";
   score = 10.0;
   symbol = "SCAM_ORDER_DE";
@@ -144,6 +157,7 @@ scam_order_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_order_en.map";
   score = 10.0;
   symbol = "SCAM_ORDER_EN";
@@ -154,6 +168,7 @@ scam_payment_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_payment_de.map";
   score = 10.0;
   symbol = "SCAM_PAYMENT_DE";
@@ -164,6 +179,7 @@ scam_payment_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_payment_en.map";
   score = 10.0;
   symbol = "SCAM_PAYMENT_EN";
@@ -174,6 +190,7 @@ scam_ransom_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_ransom_de.map";
   score = 10.0;
   symbol = "SCAM_RANSOM_DE";
@@ -184,6 +201,7 @@ scam_ransom_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_ransom_en.map";
   score = 10.0;
   symbol = "SCAM_RANSOM_EN";
@@ -194,6 +212,7 @@ scam_transaction_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_transaction_de.map";
   score = 10.0;
   symbol = "SCAM_TRANSACTION_DE";
@@ -204,6 +223,7 @@ scam_transaction_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_transaction_en.map";
   score = 10.0;
   symbol = "SCAM_TRANSACTION_EN";
@@ -216,6 +236,7 @@ scam_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_de.map";
   score = 10.0;
   symbol = "SCAM_DE";
@@ -226,6 +247,7 @@ scam_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_scam_en.map";
   score = 10.0;
   symbol = "SCAM_EN";

--- a/local.d/_multimap_stocks.conf
+++ b/local.d/_multimap_stocks.conf
@@ -14,6 +14,7 @@ stocks_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_stocks_de.map";
   score = 10.0;
   symbol = "STOCKS_DE";
@@ -24,6 +25,7 @@ stocks_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_stocks_en.map";
   score = 10.0;
   symbol = "STOCKS_EN";

--- a/local.d/_multimap_winning.conf
+++ b/local.d/_multimap_winning.conf
@@ -12,6 +12,7 @@ winning_de {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_winning_de.map";
   score = 10.0;
   symbol = "WINNING_DE";
@@ -22,6 +23,7 @@ winning_en {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/_winning_en.map";
   score = 10.0;
   symbol = "WINNING_EN";

--- a/local.d/multimap.base.body.href.conf
+++ b/local.d/multimap.base.body.href.conf
@@ -19,6 +19,7 @@ base.body.href.domain {
   type = "url";
   filter = "tld";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/base/href/base.body.href.domain.map";
   score = 12.0;
   symbol = "base.body.href.domain";
@@ -51,6 +52,7 @@ base.body.href.domain.google {
   type = "url";
   filter = "full";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/base/href/base.body.href.domain.google.map";
   score = 12.0;
   symbol = "base.body.href.domain.google";
@@ -63,6 +65,7 @@ base.body.href.nossl {
   type = "url";
   filter = "full";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/base/href/base.body.href.nossl.map";
   score = 12.0;
   symbol = "base.body.href.nossl";
@@ -99,6 +102,7 @@ base.body.href.path.wordpress {
   type = "url";
   filter = "full";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/base/href/base.body.href.path.wordpress.map";
   score = 12.0;
   symbol = "base.body.href.path.wordpress";

--- a/local.d/multimap.base.body.img.conf
+++ b/local.d/multimap.base.body.img.conf
@@ -20,6 +20,7 @@ base.body.img.domain.ip {
   type = "content";
   filter = "rawtext";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/base/img/base.body.img.domain.ip.map";
   score = 12.0;
   symbol = "base.body.img.domain.ip";
@@ -30,6 +31,7 @@ base.body.img.domain.tld {
   type = "content";
   filter = "rawtext";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/base/img/base.body.img.domain.tld.map";
   score = 12.0;
   symbol = "base.body.img.domain.tld";
@@ -40,6 +42,7 @@ base.body.img.domain.name {
   type = "content";
   filter = "rawtext";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/base/img/base.body.img.domain.name.map";
   score = 12.0;
   symbol = "base.body.img.domain.name";
@@ -52,6 +55,7 @@ base.body.img.nossl {
   type = "content";
   filter = "rawtext";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/base/img/base.body.img.nossl.map";
   score = 3.0;
   symbol = "base.body.img.nossl";
@@ -62,6 +66,7 @@ base.body.img.path {
   type = "content";
   filter = "rawtext";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/base/img/base.body.img.path.map";
   score = 12.0;
   symbol = "base.body.img.path";
@@ -72,6 +77,7 @@ base.body.img.shortener {
   type = "content";
   filter = "rawtext";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/base/img/base.body.img.shortener.map";
   score = 12.0;
   symbol = "base.body.img.shortener";

--- a/local.d/multimap.base.conf
+++ b/local.d/multimap.base.conf
@@ -52,6 +52,7 @@ base.body.markup.hidden {
   type = "content";
   filter = "rawtext";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/base/base.body.markup.hidden.map";
   score = 12.0;
   symbol = "base.body.markup.hidden";
@@ -62,6 +63,7 @@ base.body.markup {
   type = "content";
   filter = "rawtext";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/base/base.body.markup.map";
   score = 12.0;
   symbol = "base.body.markup";

--- a/local.d/multimap.body.conf
+++ b/local.d/multimap.body.conf
@@ -20,6 +20,7 @@
 body.attachment {
   type = "filename";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/body.attachment.map";
   score = 12.0;
   symbol = "body.attachment";
@@ -32,6 +33,7 @@ body.emergency {
   type = "content";
   filter = "rawtext";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/body.emergency.map";
   score = 12.0;
   symbol = "body.emergency";
@@ -44,6 +46,7 @@ body.az.orgname {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/body.az.orgname.map";
   score = 18.0;
   symbol = "body.az.orgname";
@@ -54,6 +57,7 @@ body.ch.orgname {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/body.ch.orgname.map";
   score = 18.0;
   symbol = "body.ch.orgname";
@@ -64,6 +68,7 @@ body.de.orgname {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/body.de.orgname.map";
   score = 18.0;
   symbol = "body.de.orgname";
@@ -74,6 +79,7 @@ body.us.orgname {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/body.us.orgname.map";
   score = 18.0;
   symbol = "body.us.orgname";
@@ -86,6 +92,7 @@ body.de.singleword {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/de/body.de.singleword.map";
   score = 12.0;
   symbol = "body.de.singleword";
@@ -96,6 +103,7 @@ body.de.singleword.ucase {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/de/body.de.singleword.ucase.map";
   score = 12.0;
   symbol = "body.de.singleword.ucase";
@@ -106,6 +114,7 @@ body.en.singleword {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/en/body.en.singleword.map";
   score = 12.0;
   symbol = "body.en.singleword";
@@ -116,6 +125,7 @@ body.en.singleword.ucase {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/en/body.en.singleword.ucase.map";
   score = 12.0;
   symbol = "body.en.singleword.ucase";
@@ -128,6 +138,7 @@ body.de.greetings {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/de/body.de.greetings.map";
   score = 12.0;
   symbol = "body.de.greetings";
@@ -138,6 +149,7 @@ body.en.greetings {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/en/body.en.greetings.map";
   score = 12.0;
   symbol = "body.en.greetings";
@@ -150,6 +162,7 @@ body.de.intros {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/de/body.de.intros.map";
   score = 12.0;
   symbol = "body.de.intros";
@@ -160,6 +173,7 @@ body.en.intros {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/en/body.en.intros.map";
   score = 12.0;
   symbol = "body.en.intros";
@@ -172,6 +186,7 @@ body.de.message {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/de/body.de.message.map";
   score = 12.0;
   symbol = "body.de.message";
@@ -182,6 +197,7 @@ body.en.message {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/en/body.en.message.map";
   score = 12.0;
   symbol = "body.en.message";
@@ -194,6 +210,7 @@ body.de.unsubscribe {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/de/body.de.unsubscribe.map";
   score = 12.0;
   symbol = "body.de.unsubscribe";
@@ -204,6 +221,7 @@ body.en.unsubscribe {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/en/body.en.unsubscribe.map";
   score = 12.0;
   symbol = "body.en.unsubscribe";

--- a/local.d/multimap.body.href.conf
+++ b/local.d/multimap.body.href.conf
@@ -17,6 +17,7 @@ body.href.az.domain.name {
   type = "url";
   filter = "tld";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/href/body.href.az.domain.name.map";
   score = 12.0;
   symbol = "body.href.az.domain.name";
@@ -27,6 +28,7 @@ body.href.ch.domain.name {
   type = "url";
   filter = "tld";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/href/body.href.ch.domain.name.map";
   score = 12.0;
   symbol = "body.href.ch.domain.name";
@@ -37,6 +39,7 @@ body.href.de.domain.name {
   type = "url";
   filter = "tld";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/href/body.href.de.domain.name.map";
   score = 12.0;
   symbol = "body.href.de.domain.name";
@@ -47,6 +50,7 @@ body.href.us.domain.name {
   type = "url";
   filter = "tld";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/href/body.href.us.domain.name.map";
   score = 12.0;
   symbol = "body.href.us.domain.name";
@@ -59,6 +63,7 @@ body.href.domain.name.pattern {
   type = "url";
   filter = "tld";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/href/body.href.domain.name.pattern.map";
   score = 12.0;
   symbol = "body.href.domain.name.pattern";
@@ -71,6 +76,7 @@ body.href.url.path.orgbrandprod {
   type = "url";
   filter = "full";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/body/href/body.href.url.path.orgbrandprod.map";
   score = 12.0;
   symbol = "body.href.url.path.orgbrandprod";

--- a/local.d/multimap.sender.adult.conf
+++ b/local.d/multimap.sender.adult.conf
@@ -14,6 +14,7 @@ sender.from.de.adult {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/de/sender.from.de.adult.map";
   score = 12.0;
   symbol = "sender.from.de.adult";
@@ -25,6 +26,7 @@ sender.from.en.adult {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/en/sender.from.en.adult.map";
   score = 12.0;
   symbol = "sender.from.en.adult";

--- a/local.d/multimap.sender.conf
+++ b/local.d/multimap.sender.conf
@@ -16,6 +16,7 @@ sender.address.tld {
   header = "from";
   filter = "email:domain:tld";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/lists/list.tld.map";
   score = 2.0;
   symbol = "sender.address.tld";
@@ -41,6 +42,7 @@ sender.address {
   header = "from";
   filter = "email:addr";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/sender.address.map";
   score = 12.0;
   symbol = "sender.address";
@@ -52,6 +54,7 @@ sender.from.de {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/de/sender.from.de.map";
   score = 12.0;
   symbol = "sender.from.de";
@@ -63,6 +66,7 @@ sender.from.en {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/en/sender.from.en.map";
   score = 12.0;
   symbol = "sender.from.en";
@@ -76,6 +80,7 @@ sender.from.de.singleword {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/de/sender.from.de.singleword.map";
   score = 12.0;
   symbol = "sender.from.de.singleword";
@@ -87,6 +92,7 @@ sender.from.de.singleword.ucase {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/de/sender.from.de.singleword.ucase.map";
   score = 12.0;
   symbol = "sender.from.de.singleword.ucase";
@@ -98,6 +104,7 @@ sender.from.en.singleword {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/en/sender.from.en.singleword.map";
   score = 12.0;
   symbol = "sender.from.en.singleword";
@@ -109,6 +116,7 @@ sender.from.en.singleword.ucase {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/en/sender.from.en.singleword.ucase.map";
   score = 12.0;
   symbol = "sender.from.en.singleword.ucase";
@@ -122,6 +130,7 @@ sender.from.orgbrandprod {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/sender.from.orgbrandprod.map";
   score = 12.0;
   symbol = "sender.from.orgbrandprod";
@@ -135,6 +144,7 @@ sender.from.people {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/sender.from.people.map";
   score = 12.0;
   symbol = "sender.from.people";
@@ -148,6 +158,7 @@ sender.from.special {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/sender.from.special.map";
   score = 12.0;
   symbol = "sender.from.special";

--- a/local.d/multimap.sender.finance.conf
+++ b/local.d/multimap.sender.finance.conf
@@ -13,6 +13,7 @@ sender.from.de.finance {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/de/sender.from.de.finance.map";
   score = 12.0;
   symbol = "sender.from.de.finance";
@@ -24,6 +25,7 @@ sender.from.en.finance {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/en/sender.from.en.finance.map";
   score = 12.0;
   symbol = "sender.from.en.finance";

--- a/local.d/multimap.sender.gambling.conf
+++ b/local.d/multimap.sender.gambling.conf
@@ -14,6 +14,7 @@ sender.from.de.gambling {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/de/sender.from.de.gambling.map";
   score = 12.0;
   symbol = "sender.from.de.gambling";
@@ -25,6 +26,7 @@ sender.from.en.gambling {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/en/sender.from.en.gambling.map";
   score = 12.0;
   symbol = "sender.from.en.gambling";

--- a/local.d/multimap.sender.health.conf
+++ b/local.d/multimap.sender.health.conf
@@ -18,6 +18,7 @@ sender.from.health.medname {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/lists/list.medname.map";
   score = 12.0;
   symbol = "sender.from.health.medname";
@@ -31,6 +32,7 @@ sender.from.de.health {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/de/sender.from.de.health.map";
   score = 12.0;
   symbol = "sender.from.de.health";
@@ -42,6 +44,7 @@ sender.from.en.health {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/en/sender.from.en.health.map";
   score = 12.0;
   symbol = "sender.from.en.health";

--- a/local.d/multimap.sender.lottery.conf
+++ b/local.d/multimap.sender.lottery.conf
@@ -14,6 +14,7 @@ sender.from.de.lottery {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/de/sender.from.de.lottery.map";
   score = 12.0;
   symbol = "sender.from.de.lottery";
@@ -25,6 +26,7 @@ sender.from.en.lottery {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/en/sender.from.en.lottery.map";
   score = 12.0;
   symbol = "sender.from.en.lottery";

--- a/local.d/multimap.sender.makemoney.conf
+++ b/local.d/multimap.sender.makemoney.conf
@@ -18,6 +18,7 @@ sender.from.de.makemoney {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/de/sender.from.de.makemoney.map";
   score = 12.0;
   symbol = "sender.from.de.makemoney";
@@ -29,6 +30,7 @@ sender.from.en.makemoney {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/en/sender.from.en.makemoney.map";
   score = 12.0;
   symbol = "sender.from.en.makemoney";

--- a/local.d/multimap.sender.malware.conf
+++ b/local.d/multimap.sender.malware.conf
@@ -16,6 +16,7 @@ sender.from.de.malware {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/de/sender.from.de.malware.map";
   score = 12.0;
   symbol = "sender.from.de.malware";
@@ -27,6 +28,7 @@ sender.from.en.malware {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/en/sender.from.en.malware.map";
   score = 12.0;
   symbol = "sender.from.en.malware";

--- a/local.d/multimap.sender.phishing.conf
+++ b/local.d/multimap.sender.phishing.conf
@@ -15,6 +15,7 @@ sender.from.de.phishing {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/de/sender.from.de.phishing.map";
   score = 12.0;
   symbol = "sender.from.de.phishing";
@@ -26,6 +27,7 @@ sender.from.en.phishing {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/en/sender.from.en.phishing.map";
   score = 12.0;
   symbol = "sender.from.en.phishing";
@@ -39,6 +41,7 @@ sender.from.de.phishing.orgbrandprod {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/sender.from.phishing.orgbrandprod.map";
   score = 12.0;
   symbol = "sender.from.phishing.orgbrandprod";

--- a/local.d/multimap.sender.sale.conf
+++ b/local.d/multimap.sender.sale.conf
@@ -13,6 +13,7 @@ sender.from.de.sale {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/de/sender.from.de.sale.map";
   score = 12.0;
   symbol = "sender.from.de.sale";
@@ -24,6 +25,7 @@ sender.from.en.sale {
   header = "from";
   filter = "email:name";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/sender/en/sender.from.en.sale.map";
   score = 12.0;
   symbol = "sender.from.en.sale";

--- a/local.d/multimap.subject.adult.conf
+++ b/local.d/multimap.subject.adult.conf
@@ -15,6 +15,7 @@ subject.de.adult {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.adult.map";
   score = 12.0;
   symbol = "subject.de.adult";
@@ -25,6 +26,7 @@ subject.en.adult {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.adult.map";
   score = 12.0;
   symbol = "subject.en.adult";

--- a/local.d/multimap.subject.conf
+++ b/local.d/multimap.subject.conf
@@ -13,6 +13,7 @@ subject.de {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.map";
   score = 12.0;
   symbol = "subject.de";
@@ -23,6 +24,7 @@ subject.en {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.map";
   score = 12.0;
   symbol = "subject.en";
@@ -35,6 +37,7 @@ subject.special {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/subject.special.map";
   score = 6.0;
   symbol = "subject.special";
@@ -47,6 +50,7 @@ subject.orgbrandprod {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/subject.orgbrandprod.map";
   score = 12.0;
   symbol = "subject.orgbrandprod";
@@ -59,6 +63,7 @@ subject.de.singleword {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.singleword.map";
   score = 12.0;
   symbol = "subject.de.singleword";
@@ -69,6 +74,7 @@ subject.de.singleword.ucase {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.singleword.ucase.map";
   score = 12.0;
   symbol = "subject.de.singleword.ucase";
@@ -79,6 +85,7 @@ subject.en.singleword {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.singleword.map";
   score = 12.0;
   symbol = "subject.en.singleword";
@@ -89,6 +96,7 @@ subject.en.singleword.ucase {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.singleword.ucase.map";
   score = 12.0;
   symbol = "subject.en.singleword.ucase";
@@ -101,6 +109,7 @@ subject.de.greetings {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.greetings.map";
   score = 12.0;
   symbol = "subject.de.greetings";
@@ -111,6 +120,7 @@ subject.en.greetings {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.greetings.map";
   score = 12.0;
   symbol = "subject.en.greetings";
@@ -121,6 +131,7 @@ subject.de.message {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.message.map";
   score = 12.0;
   symbol = "subject.de.message";
@@ -131,6 +142,7 @@ subject.en.message {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.message.map";
   score = 12.0;
   symbol = "subject.en.message";

--- a/local.d/multimap.subject.finance.conf
+++ b/local.d/multimap.subject.finance.conf
@@ -14,6 +14,7 @@ subject.de.finance {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.finance.map";
   score = 12.0;
   symbol = "subject.de.finance";
@@ -24,6 +25,7 @@ subject.en.finance {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.finance.map";
   score = 12.0;
   symbol = "subject.en.finance";

--- a/local.d/multimap.subject.health.conf
+++ b/local.d/multimap.subject.health.conf
@@ -17,6 +17,7 @@ subject.health.medname {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/lists/list.medname.map";
   score = 12.0;
   symbol = "subject.health.medname";
@@ -29,6 +30,7 @@ subject.de.health {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.health.map";
   score = 12.0;
   symbol = "subject.de.health";
@@ -39,6 +41,7 @@ subject.en.health {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.health.map";
   score = 12.0;
   symbol = "subject.en.health";

--- a/local.d/multimap.subject.makemoney.conf
+++ b/local.d/multimap.subject.makemoney.conf
@@ -17,6 +17,7 @@ subject.de.makemoney {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.makemoney.map";
   score = 12.0;
   symbol = "subject.de.makemoney";
@@ -27,6 +28,7 @@ subject.en.makemoney {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.makemoney.map";
   score = 12.0;
   symbol = "subject.en.makemoney";

--- a/local.d/multimap.subject.phishing.conf
+++ b/local.d/multimap.subject.phishing.conf
@@ -13,6 +13,7 @@ subject.de.phishing {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.phishing.map";
   score = 12.0;
   symbol = "subject.de.phishing";
@@ -23,6 +24,7 @@ subject.en.phishing {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.phishing.map";
   score = 12.0;
   symbol = "subject.en.phishing";
@@ -38,6 +40,7 @@ subject.de.phishing.alertaction {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.phishing.alertaction.map";
   score = 12.0;
   symbol = "subject.de.phishing.alertaction";
@@ -48,6 +51,7 @@ subject.en.phishing.alertaction {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.phishing.alertaction.map";
   score = 12.0;
   symbol = "subject.en.phishing.alertaction";
@@ -60,6 +64,7 @@ subject.de.phishing.account {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.phishing.account.map";
   score = 12.0;
   symbol = "subject.de.phishing.account";
@@ -70,6 +75,7 @@ subject.en.phishing.account {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.phishing.account.map";
   score = 12.0;
   symbol = "subject.en.phishing.account";
@@ -82,6 +88,7 @@ subject.de.phishing.banking {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.phishing.banking.map";
   score = 12.0;
   symbol = "subject.de.phishing.banking";
@@ -92,6 +99,7 @@ subject.en.phishing.banking {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.phishing.banking.map";
   score = 12.0;
   symbol = "subject.en.phishing.banking";
@@ -104,6 +112,7 @@ subject.de.phishing.email {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.phishing.email.map";
   score = 12.0;
   symbol = "subject.de.phishing.email";
@@ -114,6 +123,7 @@ subject.en.phishing.email {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.phishing.email.map";
   score = 12.0;
   symbol = "subject.en.phishing.email";
@@ -126,6 +136,7 @@ subject.de.phishing.malware {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.phishing.malware.map";
   score = 12.0;
   symbol = "subject.de.phishing.malware";
@@ -136,6 +147,7 @@ subject.en.phishing.malware {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.phishing.malware.map";
   score = 12.0;
   symbol = "subject.en.phishing.malware";
@@ -148,6 +160,7 @@ subject.de.phishing.parcel {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.phishing.parcel.map";
   score = 12.0;
   symbol = "subject.de.phishing.parcel";
@@ -158,6 +171,7 @@ subject.en.phishing.parcel {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.phishing.parcel.map";
   score = 12.0;
   symbol = "subject.en.phishing.parcel";
@@ -170,6 +184,7 @@ subject.de.phishing.payment {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.phishing.payment.map";
   score = 12.0;
   symbol = "subject.de.phishing.payment";
@@ -180,6 +195,7 @@ subject.en.phishing.payment {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.phishing.payment.map";
   score = 12.0;
   symbol = "subject.en.phishing.payment";
@@ -192,6 +208,7 @@ subject.de.phishing.rewards {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.phishing.rewards.map";
   score = 12.0;
   symbol = "subject.de.phishing.rewards";
@@ -202,6 +219,7 @@ subject.en.phishing.rewards {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.phishing.rewards.map";
   score = 12.0;
   symbol = "subject.en.phishing.rewards";

--- a/local.d/multimap.subject.sale.conf
+++ b/local.d/multimap.subject.sale.conf
@@ -17,6 +17,7 @@ subject.de.sale {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.sale.map";
   score = 12.0;
   symbol = "subject.de.sale";
@@ -27,6 +28,7 @@ subject.en.sale {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.sale.map";
   score = 12.0;
   symbol = "subject.en.sale";
@@ -37,6 +39,7 @@ subject.en.sale.china {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.sale.china.map";
   score = 12.0;
   symbol = "subject.en.sale.china";
@@ -49,6 +52,7 @@ subject.de.sale.app {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.sale.app.map";
   score = 12.0;
   symbol = "subject.de.sale.app";
@@ -59,6 +63,7 @@ subject.en.sale.app {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.sale.app.map";
   score = 12.0;
   symbol = "subject.en.sale.app";
@@ -69,6 +74,7 @@ subject.de.sale.seo {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.sale.seo.map";
   score = 12.0;
   symbol = "subject.de.sale.seo";
@@ -79,6 +85,7 @@ subject.en.sale.seo {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.sale.seo.map";
   score = 12.0;
   symbol = "subject.en.sale.seo";
@@ -89,6 +96,7 @@ subject.de.sale.website {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.sale.website.map";
   score = 12.0;
   symbol = "subject.de.sale.website";
@@ -99,6 +107,7 @@ subject.en.sale.website {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.sale.website.map";
   score = 12.0;
   symbol = "subject.en.sale.website";

--- a/local.d/multimap.subject.scam.conf
+++ b/local.d/multimap.subject.scam.conf
@@ -14,6 +14,7 @@ subject.de.scam {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.scam.map";
   score = 12.0;
   symbol = "subject.de.scam";
@@ -24,6 +25,7 @@ subject.en.scam {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.scam.map";
   score = 12.0;
   symbol = "subject.en.scam";
@@ -39,6 +41,7 @@ subject.de.scam.bignumbers {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.scam.bignumbers.map";
   score = 12.0;
   symbol = "subject.de.scam.bignumbers";
@@ -49,6 +52,7 @@ subject.en.scam.bignumbers {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.scam.bignumbers.map";
   score = 12.0;
   symbol = "subject.en.scam.bignumbers";
@@ -61,6 +65,7 @@ subject.de.scam.donation {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.scam.donation.map";
   score = 12.0;
   symbol = "subject.de.scam.donation";
@@ -71,6 +76,7 @@ subject.en.scam.donation {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.scam.donation.map";
   score = 12.0;
   symbol = "subject.en.scam.donation";
@@ -83,6 +89,7 @@ subject.de.scam.order {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.scam.order.map";
   score = 12.0;
   symbol = "subject.de.scam.order";
@@ -93,6 +100,7 @@ subject.en.scam.order {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.scam.order.map";
   score = 12.0;
   symbol = "subject.en.scam.order";
@@ -105,6 +113,7 @@ subject.de.scam.winning {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/de/subject.de.scam.winning.map";
   score = 12.0;
   symbol = "subject.de.scam.winning";
@@ -115,6 +124,7 @@ subject.en.scam.winning {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/subject/en/subject.en.scam.winning.map";
   score = 12.0;
   symbol = "subject.en.scam.winning";

--- a/local.d/multimap.whitelist.conf
+++ b/local.d/multimap.whitelist.conf
@@ -13,6 +13,7 @@ subject.de.whitelist {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/whitelist/de/subject.de.whitelist.map";
   score = -0.5;
   symbol = "subject.de.whitelist";
@@ -23,6 +24,7 @@ subject.en.whitelist {
   type = "header";
   header = "subject";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/whitelist/en/subject.en.whitelist.map";
   score = -0.5;
   symbol = "subject.en.whitelist";
@@ -33,6 +35,7 @@ body.de.whitelist {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/whitelist/de/body.de.whitelist.map";
   score = -0.5;
   symbol = "body.de.whitelist";
@@ -43,6 +46,7 @@ body.en.whitelist {
   type = "content";
   filter = "oneline";
   regexp = true;
+  one_shot = true;
   map = "https://raw.githubusercontent.com/martinschaible/rspamd-rules/main/maps.d/whitelist/en/body.en.whitelist.map";
   score = -0.5;
   symbol = "body.en.whitelist";


### PR DESCRIPTION
Hi Martin,

Today, I have observed a tremendous **score gain of +240** for a message due to multiple matches of a multimap, although the individual score for the specific symbol `body.href.de.domain.name` was set to just 12.0:
`body.href.de.domain.name • Body: Anchor Tag Domain Name Germany (240) [newslettertogo.com]`

Therefore, I would suggest to add `one_shot = true;` to all map definition, so that multiple matches are only counted once.

Thanks a lot for the great work!