### PR TITLE
Fix misspelling

### DIFF
--- a/maps.d/subject/de/subject.de.phishing.map
+++ b/maps.d/subject/de/subject.de.phishing.map
@@ -9,7 +9,7 @@
 # Cloud  Storage
 # ------------------------------------------------------------------------------
 /cloud.{1,10}speicher.{1,10}kritisch voll/i
-//cloud.{1,10}speicher ist voll/i
+/cloud.{1,10}speicher ist voll/i
 #/cloud.{1,10}speicher ist voll.{1,10}dateien in gefahr/i
 /cloud.{1,10}speicher sind da/i
 


### PR DESCRIPTION
Because of this misspelling every mail in our rspamd currently gets the symbol "ist"...